### PR TITLE
Redirect user to login on 401 response

### DIFF
--- a/src/store/api.js
+++ b/src/store/api.js
@@ -4,6 +4,13 @@ const api = Axios.create({
   withCredentials: true
 });
 
+api.interceptors.response.use(undefined, error => {
+  let response = error.response;
+  if (response.status == 401) {
+    window.location = '/login';
+  }
+});
+
 export default {
   get(path) {
     return api.get(path);


### PR DESCRIPTION
I am using the location property since it the full page post, opposed to using vue router, will clear all application state. I expect we will want to log a user out for inactivity rather than wait for the user to interact with the page after the session has timed out. 

I saw in BMC Web the session is 60 minutes and I believe that is updates on requests. Approve this if you think we can move this forward and decide on a solution for handling session timeouts/user inactivity at a later point in time.