### PR TITLE
Add login form validation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import router from './router';
 import store from './store';
 import { dateFilter } from 'vue-date-fns';
 import {
+  AlertPlugin,
   BadgePlugin,
   ButtonPlugin,
   CollapsePlugin,
@@ -24,6 +25,7 @@ import {
 
 Vue.filter('date', dateFilter);
 
+Vue.use(AlertPlugin);
 Vue.use(BadgePlugin);
 Vue.use(ButtonPlugin);
 Vue.use(CollapsePlugin);

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -9,12 +9,16 @@ api.interceptors.response.use(undefined, error => {
   let response = error.response;
 
   if (response.status == 401) {
-    window.location = '/login';
+    if (response.config.url != '/login') {
+      window.location = '/login';
+    }
   }
 
   if (response.status == 403) {
     router.push({ name: 'unauthorized' });
   }
+
+  return Promise.reject(error);
 });
 
 export default {

--- a/src/store/modules/Authentication/AuthenticanStore.js
+++ b/src/store/modules/Authentication/AuthenticanStore.js
@@ -13,7 +13,7 @@ const AuthenticationStore = {
   },
   mutations: {
     authRequest(state) {
-      state.status = 'loading';
+      state.status = 'processing';
     },
     authSuccess(state) {
       state.status = 'authenticated';

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -108,7 +108,7 @@ export default {
             this.$router.push('/');
           })
           .catch(error => {
-            this.errorMsg.title = 'Inavalid username or password.';
+            this.errorMsg.title = 'Invalid username or password.';
             this.errorMsg.action = 'Please try again.';
             console.log(error);
           })

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -14,13 +14,27 @@
       </b-col>
 
       <b-col class="login-form" md="6">
-        <b-form @submit.prevent="login">
+        <b-form @submit.prevent="login" novalidate>
+          <b-alert
+            class="login-error"
+            v-if="errorMsg.title"
+            show
+            variant="danger"
+          >
+            <h2>{{ errorMsg.title }}</h2>
+            <p v-if="errorMsg.action">{{ errorMsg.action }}</p>
+          </b-alert>
           <b-form-group
             id="username-group"
             label="Username"
             label-for="username"
           >
-            <b-form-input id="username" v-model="username" type="text" required>
+            <b-form-input
+              id="username"
+              v-model="userInfo.username"
+              type="text"
+              required
+            >
             </b-form-input>
           </b-form-group>
 
@@ -31,14 +45,19 @@
           >
             <b-form-input
               id="password"
-              v-model="password"
+              v-model="userInfo.password"
               type="password"
               required
             >
             </b-form-input>
           </b-form-group>
 
-          <b-button type="submit" variant="primary">Login</b-button>
+          <b-button
+            type="submit"
+            :disabled="disableSubmitButton"
+            variant="primary"
+            >Login</b-button
+          >
         </b-form>
       </b-col>
     </b-row>
@@ -50,18 +69,54 @@ export default {
   name: 'Login',
   data() {
     return {
-      username: '',
-      password: ''
+      errorMsg: {
+        title: null,
+        action: null
+      },
+      userInfo: {
+        username: null,
+        password: null
+      },
+      disableSubmitButton: false,
+      submitButtonText: 'Login'
     };
   },
   methods: {
+    validateForm: function() {
+      this.errorMsg.title = null;
+      this.errorMsg.action = null;
+
+      // Name error message
+      if (!this.userInfo.username || !this.userInfo.password) {
+        this.errorMsg.title = 'Username and password required.';
+      }
+
+      if (!this.errorMsg.title) {
+        return true;
+      }
+
+      return false;
+    },
     login: function() {
-      const username = this.username;
-      const password = this.password;
-      this.$store
-        .dispatch('authentication/login', [username, password])
-        .then(() => this.$router.push('/'))
-        .catch(error => console.log(error));
+      const isValidForm = this.validateForm();
+      if (isValidForm) {
+        const username = this.userInfo.username;
+        const password = this.userInfo.password;
+        this.disableSubmitButton = true;
+        this.$store
+          .dispatch('authentication/login', [username, password])
+          .then(() => {
+            this.$router.push('/');
+          })
+          .catch(error => {
+            this.errorMsg.title = 'Inavalid username or password.';
+            this.errorMsg.action = 'Please try again.';
+            console.log(error);
+          })
+          .finally(() => {
+            this.disableSubmitButton = false;
+          });
+      }
     }
   }
 };
@@ -102,6 +157,18 @@ export default {
 
   @include media-breakpoint-up(md) {
     margin-left: 4rem;
+  }
+}
+
+.login-error {
+  h2 {
+    font-size: 1rem;
+    margin-bottom: 0;
+  }
+
+  p {
+    margin-top: 0.5rem;
+    margin-bottom: 0;
   }
 }
 

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -56,7 +56,7 @@
             type="submit"
             :disabled="disableSubmitButton"
             variant="primary"
-            >Login</b-button
+            >Log in</b-button
           >
         </b-form>
       </b-col>
@@ -77,8 +77,7 @@ export default {
         username: null,
         password: null
       },
-      disableSubmitButton: false,
-      submitButtonText: 'Login'
+      disableSubmitButton: false
     };
   },
   methods: {
@@ -88,13 +87,10 @@ export default {
 
       if (!this.userInfo.username || !this.userInfo.password) {
         this.errorMsg.title = 'Username and password required.';
+        return false;
       }
 
-      if (!this.errorMsg.title) {
-        return true;
-      }
-
-      return false;
+      return true;
     },
     login: function() {
       const isValidForm = this.validateForm();
@@ -166,7 +162,7 @@ export default {
   }
 
   p {
-    margin-top: 0.5rem;
+    margin-top: $spacer / 2;
     margin-bottom: 0;
   }
 }

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -86,7 +86,6 @@ export default {
       this.errorMsg.title = null;
       this.errorMsg.action = null;
 
-      // Name error message
       if (!this.userInfo.username || !this.userInfo.password) {
         this.errorMsg.title = 'Username and password required.';
       }


### PR DESCRIPTION
- Sending incorrect credentials returns a 401 and we don't want the page
to redirect if we are trying to login. Wrapped the redirect in an if
block.
- Returning a promise used by the logout  action, which is needed
when not redirecting the page.  Didn't add to the if block since
other errors that use the router to redirect will need the Promise
returned also, e.g. 403.