### PR TITLE
Update button variant styles

### DIFF
--- a/src/assets/styles/_buttons.scss
+++ b/src/assets/styles/_buttons.scss
@@ -1,4 +1,5 @@
 .btn {
+  font-weight: $headings-font-weight;
   svg {
     vertical-align: sub;
     margin-left: $spacer / 2;

--- a/src/assets/styles/_buttons.scss
+++ b/src/assets/styles/_buttons.scss
@@ -1,0 +1,26 @@
+.btn {
+  svg {
+    vertical-align: sub;
+    margin-left: $spacer / 2;
+  }
+}
+
+.btn-primary {
+  fill: $white;
+}
+
+.btn-secondary {
+  fill: $white;
+  @extend .btn-secondary-dark;
+}
+
+.btn-link {
+  fill: $primary;
+  text-decoration: none !important;
+  &:focus {
+    box-shadow: $btn-focus-box-shadow;
+  }
+  &:hover {
+    fill: darken($primary, 15%);
+  }
+}

--- a/src/assets/styles/_obmc-custom.scss
+++ b/src/assets/styles/_obmc-custom.scss
@@ -1,3 +1,5 @@
+$enable-rounded: false;
+
 // Required
 @import "~bootstrap/scss/functions";
 @import "./functions";
@@ -51,6 +53,3 @@ $colors: map-remove($theme-colors, "light", "dark");
 @import "~bootstrap-vue/src/index.scss";
 
 @import "./buttons";
-
-// Overrides should be imported last
-@import "./overrides";

--- a/src/assets/styles/_obmc-custom.scss
+++ b/src/assets/styles/_obmc-custom.scss
@@ -49,3 +49,8 @@ $colors: map-remove($theme-colors, "light", "dark");
 @import "~bootstrap/scss/print";
 
 @import "~bootstrap-vue/src/index.scss";
+
+@import "./buttons";
+
+// Overrides should be imported last
+@import "./overrides";

--- a/src/assets/styles/_overrides.scss
+++ b/src/assets/styles/_overrides.scss
@@ -1,5 +1,0 @@
-// Global overrides
-
-.btn {
-  border-radius: 0;
-}

--- a/src/assets/styles/_overrides.scss
+++ b/src/assets/styles/_overrides.scss
@@ -1,0 +1,5 @@
+// Global overrides
+
+.btn {
+  border-radius: 0;
+}

--- a/src/views/AccessControl/LocalUserManagement/LocalUserManagement.vue
+++ b/src/views/AccessControl/LocalUserManagement/LocalUserManagement.vue
@@ -8,12 +8,12 @@
     <b-row>
       <b-col lg="10">
         <b-button @click="initModalSettings" variant="link">
-          <icon-settings />
           Account policy settings
+          <icon-settings />
         </b-button>
         <b-button @click="initModalUser(null)" variant="primary">
-          <icon-add />
           Add user
+          <icon-add />
         </b-button>
       </b-col>
     </b-row>


### PR DESCRIPTION
Adding styles to leverage bootstrap-vue button components.
Using the link variant as a replacement for our current 'ghost'
button style. Since bootstrap buttons are rounded by default
and rounded vs straight corners isn't agreed on by community,
creating a global overrides file to capture any company specific
style overrides.

Signed-off-by: Yoshie Muranaka <yoshiemuranaka@gmail.com>