### PR TITLE
Use vue recommended ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   env: {
     node: true
   },
-  extends: ['plugin:vue/essential', '@vue/prettier'],
+  extends: ['plugin:vue/recommended', '@vue/prettier'],
   rules: {
     'no-console': 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
@@ -12,7 +12,8 @@ module.exports = {
       {
         singleQuote: true
       }
-    ]
+    ],
+    'vue/component-name-in-template-casing': ['error', 'kebab-case']
   },
   parserOptions: {
     parser: 'babel-eslint'

--- a/src/components/AppHeader/AppHeader.vue
+++ b/src/components/AppHeader/AppHeader.vue
@@ -42,9 +42,6 @@ import StatusIcon from '../Global/StatusIcon';
 export default {
   name: 'AppHeader',
   components: { IconAvatar, IconRenew, StatusIcon },
-  created() {
-    this.getHostInfo();
-  },
   computed: {
     hostStatus() {
       return this.$store.getters['global/hostStatus'];
@@ -60,6 +57,9 @@ export default {
           return 'secondary';
       }
     }
+  },
+  created() {
+    this.getHostInfo();
   },
   methods: {
     getHostInfo() {

--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -7,7 +7,7 @@
         <icon-health />Health
         <icon-expand class="icon-expand" />
       </b-button>
-      <b-collapse tag="ul" id="health-menu" class="nav-item__nav">
+      <b-collapse id="health-menu" tag="ul" class="nav-item__nav">
         <b-nav-item href="javascript:void(0)">Event Log</b-nav-item>
         <b-nav-item href="javascript:void(0)">Hardware Status</b-nav-item>
         <b-nav-item href="javascript:void(0)">Sensors</b-nav-item>
@@ -19,7 +19,7 @@
         <icon-control />Control
         <icon-expand class="icon-expand" />
       </b-button>
-      <b-collapse tag="ul" id="control-menu" class="nav-item__nav">
+      <b-collapse id="control-menu" tag="ul" class="nav-item__nav">
         <b-nav-item href="javascript:void(0)">
           Server power operations
         </b-nav-item>
@@ -33,7 +33,7 @@
         <icon-configuration />Configuration
         <icon-expand class="icon-expand" />
       </b-button>
-      <b-collapse tag="ul" id="configuration-menu" class="nav-item__nav">
+      <b-collapse id="configuration-menu" tag="ul" class="nav-item__nav">
         <b-nav-item href="javascript:void(0)">Network settings</b-nav-item>
         <b-nav-item href="javascript:void(0)">SNMP settings</b-nav-item>
         <b-nav-item href="javascript:void(0)">Firmware</b-nav-item>
@@ -45,7 +45,7 @@
         <icon-access-control />Access Control
         <icon-expand class="icon-expand" />
       </b-button>
-      <b-collapse tag="ul" id="access-control-menu" class="nav-item__nav">
+      <b-collapse id="access-control-menu" tag="ul" class="nav-item__nav">
         <b-nav-item href="javascript:void(0)">LDAP</b-nav-item>
         <b-nav-item to="/access-control/local-user-management">
           Local user management

--- a/src/components/Global/PageSection.vue
+++ b/src/components/Global/PageSection.vue
@@ -8,7 +8,12 @@
 <script>
 export default {
   name: 'PageSection',
-  props: ['sectionTitle']
+  props: {
+    sectionTitle: {
+      type: String,
+      required: true
+    }
+  }
 };
 </script>
 

--- a/src/components/Global/PageTitle.vue
+++ b/src/components/Global/PageTitle.vue
@@ -8,7 +8,12 @@
 <script>
 export default {
   name: 'PageTitle',
-  props: ['description'],
+  props: {
+    description: {
+      type: String,
+      default: ''
+    }
+  },
   data() {
     return {
       title: this.$route.meta.title

--- a/src/components/Global/StatusIcon.vue
+++ b/src/components/Global/StatusIcon.vue
@@ -13,11 +13,16 @@ import IconError from '@carbon/icons-vue/es/error--filled/20';
 
 export default {
   name: 'StatusIcon',
-  props: ['status'],
   components: {
     iconSuccess: IconCheckmark,
     iconDanger: IconWarning,
     iconSecondary: IconError
+  },
+  props: {
+    status: {
+      type: String,
+      default: ''
+    }
   }
 };
 </script>

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
-    <AppHeader ref="focusTarget" />
+    <app-header ref="focusTarget" />
     <b-container fluid class="page-container">
       <b-row no-gutters>
         <b-col tag="nav" cols="12" md="3" lg="2">
-          <AppNavigation />
+          <app-navigation />
         </b-col>
         <b-col cols="12" md="9" lg="10">
-          <PageContainer>
+          <page-container>
             <router-view ref="routerView" />
-          </PageContainer>
+          </page-container>
         </b-col>
       </b-row>
     </b-container>

--- a/src/views/AccessControl/LocalUserManagement/LocalUserManagement.vue
+++ b/src/views/AccessControl/LocalUserManagement/LocalUserManagement.vue
@@ -1,13 +1,13 @@
 <template>
   <b-container class="ml-0">
-    <PageTitle />
+    <page-title />
     <b-row>
       <b-col lg="10">
-        <b-button @click="initModalSettings" variant="link">
+        <b-button variant="link" @click="initModalSettings">
           Account policy settings
           <icon-settings />
         </b-button>
-        <b-button @click="initModalUser(null)" variant="primary">
+        <b-button variant="primary" @click="initModalUser(null)">
           Add user
           <icon-add />
         </b-button>
@@ -49,9 +49,9 @@
       </b-col>
     </b-row>
     <!-- Modals -->
-    <modal-settings v-bind:settings="settings"></modal-settings>
+    <modal-settings :settings="settings"></modal-settings>
     <modal-user
-      v-bind:user="activeUser"
+      :user="activeUser"
       @ok="saveUser"
       @hidden="clearActiveUser"
     ></modal-user>
@@ -70,7 +70,7 @@ import ModalSettings from './ModalSettings';
 import PageTitle from '../../../components/Global/PageTitle';
 
 export default {
-  name: 'local-users',
+  name: 'LocalUsers',
   components: {
     IconAdd,
     IconEdit,
@@ -86,9 +86,6 @@ export default {
       activeUser: null,
       settings: null
     };
-  },
-  created() {
-    this.getUsers();
   },
   computed: {
     allUsers() {
@@ -112,6 +109,9 @@ export default {
         };
       });
     }
+  },
+  created() {
+    this.getUsers();
   },
   methods: {
     getUsers() {

--- a/src/views/AccessControl/LocalUserManagement/ModalSettings.vue
+++ b/src/views/AccessControl/LocalUserManagement/ModalSettings.vue
@@ -4,6 +4,11 @@
 
 <script>
 export default {
-  props: ['settings']
+  props: {
+    settings: {
+      type: String,
+      default: ''
+    }
+  }
 };
 </script>

--- a/src/views/AccessControl/LocalUserManagement/ModalUser.vue
+++ b/src/views/AccessControl/LocalUserManagement/ModalUser.vue
@@ -22,7 +22,7 @@
         >
       </b-form-group>
       <b-form-group label="Username">
-        <b-form-input type="text" v-model="form.username" />
+        <b-form-input v-model="form.username" type="text" />
       </b-form-group>
       <b-form-group label="Privilege">
         <b-form-select
@@ -31,7 +31,7 @@
         ></b-form-select>
       </b-form-group>
       <b-form-group label="Password">
-        <b-form-input type="password" v-model="form.password" />
+        <b-form-input v-model="form.password" type="password" />
       </b-form-group>
     </b-form>
     <template v-slot:modal-ok>
@@ -47,7 +47,12 @@
 
 <script>
 export default {
-  props: ['user'],
+  props: {
+    user: {
+      type: Object,
+      default: null
+    }
+  },
   data() {
     return {
       privilegeTypes: ['Administrator', 'Operator', 'ReadOnly', 'NoAccess']

--- a/src/views/AccessControl/LocalUserManagement/TableRoles.vue
+++ b/src/views/AccessControl/LocalUserManagement/TableRoles.vue
@@ -2,22 +2,22 @@
   <b-table bordered small head-variant="dark" :items="items" :fields="fields">
     <template v-slot:cell(administrator)="data">
       <template v-if="data.value">
-        <Checkmark20 />
+        <checkmark20 />
       </template>
     </template>
     <template v-slot:cell(operator)="data">
       <template v-if="data.value">
-        <Checkmark20 />
+        <checkmark20 />
       </template>
     </template>
     <template v-slot:cell(readonly)="data">
       <template v-if="data.value">
-        <Checkmark20 />
+        <checkmark20 />
       </template>
     </template>
     <template v-slot:cell(noaccess)="data">
       <template v-if="data.value">
-        <Checkmark20 />
+        <checkmark20 />
       </template>
     </template>
   </b-table>

--- a/src/views/Login/Login.vue
+++ b/src/views/Login/Login.vue
@@ -14,10 +14,10 @@
       </b-col>
 
       <b-col class="login-form" md="6">
-        <b-form @submit.prevent="login" novalidate>
+        <b-form novalidate @submit.prevent="login">
           <b-alert
-            class="login-error"
             v-if="errorMsg.title"
+            class="login-error"
             show
             variant="danger"
           >

--- a/src/views/Overview/Overview.vue
+++ b/src/views/Overview/Overview.vue
@@ -1,9 +1,9 @@
 <template>
   <b-container fluid>
-    <PageTitle />
+    <page-title />
     <b-row>
       <b-col lg="8" sm="12">
-        <PageSection sectionTitle="Server information">
+        <page-section section-title="Server information">
           <b-row>
             <b-col sm="6">
               <dl>
@@ -30,8 +30,8 @@
               </dl>
             </b-col>
           </b-row>
-        </PageSection>
-        <PageSection sectionTitle="BMC information">
+        </page-section>
+        <page-section section-title="BMC information">
           <b-row>
             <b-col sm="6">
               <dl>
@@ -48,7 +48,7 @@
             <b-col sm="6">
               <dl>
                 <dt>IP address</dt>
-                <dd v-for="ip in ipAddress" v-bind:key="ip.id">{{ ip }}</dd>
+                <dd v-for="ip in ipAddress" :key="ip.id">{{ ip }}</dd>
               </dl>
             </b-col>
             <b-col sm="6">
@@ -58,8 +58,8 @@
               </dl>
             </b-col>
           </b-row>
-        </PageSection>
-        <PageSection sectionTitle="Power consumption">
+        </page-section>
+        <page-section section-title="Power consumption">
           <b-row>
             <b-col sm="6">
               <dl>
@@ -74,15 +74,15 @@
               </dl>
             </b-col>
           </b-row>
-        </PageSection>
+        </page-section>
       </b-col>
       <b-col lg="4" sm="12">
-        <OverviewQuickLinks />
+        <overview-quick-links />
       </b-col>
     </b-row>
-    <PageSection sectionTitle="High priority events">
-      <OverviewEvents />
-    </PageSection>
+    <page-section section-title="High priority events">
+      <overview-events />
+    </page-section>
   </b-container>
 </template>
 
@@ -101,9 +101,6 @@ export default {
     PageTitle,
     PageSection
   },
-  created() {
-    this.getOverviewInfo();
-  },
   computed: mapState({
     serverModel: state => state.overview.serverModel,
     serverManufacturer: state => state.overview.serverManufacturer,
@@ -116,6 +113,10 @@ export default {
     ipAddress: state => state.networkSettings.ipAddress,
     macAddress: state => state.networkSettings.macAddress
   }),
+  created() {
+    this.getOverviewInfo();
+  },
+
   methods: {
     getOverviewInfo() {
       this.$store.dispatch('overview/getServerInfo');

--- a/src/views/Overview/OverviewEvents.vue
+++ b/src/views/Overview/OverviewEvents.vue
@@ -8,7 +8,7 @@
           <small>{{
             logData.Timestamp | date('MMM DD YYYY HH:MM:SS A ZZ')
           }}</small>
-          <ChevronRight16 />
+          <chevron-right16 />
         </div>
         <p class="mb-1">{{ logData.eventID }}: {{ logData.description }}</p>
       </b-list-group-item>
@@ -23,17 +23,17 @@
 import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
 
 export default {
-  name: 'events',
+  name: 'Events',
   components: {
     ChevronRight16
-  },
-  created() {
-    this.getEventLogData();
   },
   computed: {
     eventLogData() {
       return this.$store.getters['eventLog/eventLogData'];
     }
+  },
+  created() {
+    this.getEventLogData();
   },
   methods: {
     getEventLogData() {

--- a/src/views/Overview/OverviewQuickLinks.vue
+++ b/src/views/Overview/OverviewQuickLinks.vue
@@ -21,7 +21,7 @@
     >
       <!-- TODO: link to SOL -->
       <span>Serial over LAN console</span>
-      <ChevronRight16 />
+      <chevron-right16 />
     </b-list-group-item>
     <b-list-group-item
       href="#"
@@ -29,7 +29,7 @@
     >
       <!-- TODO: link to network settings -->
       <span>Edit network settings</span>
-      <ChevronRight16 />
+      <chevron-right16 />
     </b-list-group-item>
   </b-list-group>
 </template>
@@ -38,27 +38,27 @@
 import ChevronRight16 from '@carbon/icons-vue/es/chevron--right/16';
 
 export default {
-  name: 'quickLinks',
+  name: 'QuickLinks',
   components: {
     ChevronRight16
   },
-  created() {
-    this.getBmcTime();
+  data() {
+    return {
+      serverLEDChecked: false
+    };
   },
   computed: {
     bmcTime() {
       return this.$store.getters['global/bmcTime'];
     }
   },
+  created() {
+    this.getBmcTime();
+  },
   methods: {
     getBmcTime() {
       this.$store.dispatch('global/getBmcTime');
     }
-  },
-  data() {
-    return {
-      serverLEDChecked: false
-    };
   }
 };
 </script>

--- a/src/views/Unauthorized/Unauthorized.vue
+++ b/src/views/Unauthorized/Unauthorized.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <PageTitle :description="description" />
+    <page-title :description="description" />
   </div>
 </template>
 <script>


### PR DESCRIPTION
- Changed the ESLint rules to use  Priority 4: Recommended and updated
all the files that needed to be updated.
- Changed vue/component-name-in-tempate-casing to use kebab-case
naming since Bootstrap vue plugin uses that naming convention.
ESLint Strongly recommended defaults to PascalCase, but kebab-case is
also listed as acceptable.

Resolves: #71

Signed-off-by: Derick Montague <derick.montague@ibm.com>